### PR TITLE
High-pass instead of low-pass, fix typo

### DIFF
--- a/modules/generated/nistats.design_matrix.make_first_level_design_matrix.html
+++ b/modules/generated/nistats.design_matrix.make_first_level_design_matrix.html
@@ -259,7 +259,7 @@ Specifies the hemodynamic response function</p>
 </div></blockquote>
 <p><strong>period_cut</strong> : float, optional</p>
 <blockquote>
-<div><p>Cut period of the low-pass filter in seconds.</p>
+<div><p>Cut period of the high-pass filter in seconds.</p>
 </div></blockquote>
 <p><strong>drift_order</strong> : int, optional</p>
 <blockquote>


### PR DESCRIPTION
To be in accordance with the function documentation for make_first_level_design_matrix.